### PR TITLE
Update way we draw reference planes

### DIFF
--- a/examples/generate_catalogs.jl
+++ b/examples/generate_catalogs.jl
@@ -1,6 +1,7 @@
 dir_path = dirname(@__FILE__)
 
 include(joinpath(dir_path, "../src/clusters.jl"))
+include(joinpath(dir_path, "../src/planetary_catalog.jl"))
 
 ##### To generate one physical and observed catalog:
 

--- a/examples/generate_catalogs_multiple.jl
+++ b/examples/generate_catalogs_multiple.jl
@@ -1,6 +1,7 @@
 dir_path = dirname(@__FILE__)
 
 include(joinpath(dir_path, "../src/clusters.jl"))
+include(joinpath(dir_path, "../src/planetary_catalog.jl"))
 
 sim_param = setup_sim_param_model()
 add_param_fixed(sim_param,"num_targets_sim_pass_one", 79935*5)

--- a/src/AMD_stability/amd_stability.jl
+++ b/src/AMD_stability/amd_stability.jl
@@ -559,7 +559,7 @@ function distribute_AMD_planet_ecc_incl_random(AMD::Real, μ::Real, a::Real)
     e = sqrt(xsq + ysq) # eccentricity
     ω = asin(sqrt(xsq)/e) # argument of pericenter
     i = asin(sqrt(zsq)) # inclination relative to invariant plane (rad)
-    @assert(sqrt(1 - e^2)*cos(i) >= 1 - AMD/Λ) # NOTE: I expected this to be equal given how we assigned x^2+y^2+z^2 = (AMD/Λ)*(2 - AMD/Λ), but in practice it is >= (which does not break AMD stability since this implies the true AMD given (e,i) is less than the AMD provided)
+    #@assert(sqrt(1 - e^2)*cos(i) >= 1 - AMD/Λ) # NOTE: I expected this to be equal given how we assigned x^2+y^2+z^2 = (AMD/Λ)*(2 - AMD/Λ), but in practice it is >= (which does not break AMD stability since this implies the true AMD given (e,i) is less than the AMD provided)
     #@info("e = $e, ω = $(ω*180/π) deg, i = $(i*180/π) deg")
 
     return e, ω, i

--- a/src/catalog_simulation.jl
+++ b/src/catalog_simulation.jl
@@ -9,9 +9,14 @@ function save_physical_catalog(cat_phys::KeplerPhysicalCatalog, sim_param::SimPa
         if length(targ.sys) > 1 #this should never happen
             println("There is more than one system for a given target? Check index: ", i)
         end
+        sys = targ.sys[1]
         if length(targ.sys[1].planet) > 0
+            incl_ref = sys.system_plane.incl
+            Ω_ref = sys.system_plane.asc_node
             for (j,planet) in enumerate(targ.sys[1].planet)
-                println(f, join([i, targ.sys[1].star.id, planet.mass, planet.radius, planet.id, targ.sys[1].orbit[j].P, targ.sys[1].orbit[j].ecc, targ.sys[1].orbit[j].incl_mut, targ.sys[1].star.mass, targ.sys[1].star.radius], ","))
+                incl_pl, Ω_pl = sys.orbit[j].incl, sys.orbit[j].asc_node
+                inclmut_pl = calc_incl_spherical_cosine_law(incl_ref, incl_pl, Ω_pl-Ω_ref)
+                println(f, join([i, sys.star.id, planet.mass, planet.radius, planet.id, sys.orbit[j].P, sys.orbit[j].ecc, inclmut_pl, sys.star.mass, sys.star.radius], ","))
             end
         end
     end
@@ -27,7 +32,8 @@ function save_physical_catalog_stars_only(cat_phys::KeplerPhysicalCatalog, sim_p
         if length(targ.sys) > 1 #this should never happen
             println("There is more than one system for a given target? Check index: ", i)
         end
-        println(f, join([i, targ.sys[1].star.id, targ.sys[1].star.mass, targ.sys[1].star.radius, length(targ.sys[1].planet)], ","))
+        sys = targ.sys[1]
+        println(f, join([i, sys.star.id, sys.star.mass, sys.star.radius, length(sys.planet)], ","))
     end
     close(f)
 end
@@ -86,9 +92,12 @@ function save_mutualinclinations_all(cat_phys::KeplerPhysicalCatalog, sim_param:
     write_model_params(f, sim_param)
     for (i,targ) in enumerate(cat_phys.target)
         if length(targ.sys[1].orbit) > 0
+            incl_ref = targ.sys[1].system_plane.incl
+            Ω_ref = targ.sys[1].system_plane.asc_node
             inclmut_sys = Array{Float64}(undef, length(targ.sys[1].orbit))
             for (j,planet) in enumerate(targ.sys[1].orbit)
-                inclmut_sys[j] = planet.incl_mut
+                incl_pl, Ω_pl = planet.incl, planet.asc_node
+                inclmut_sys[j] = calc_incl_spherical_cosine_law(incl_ref, incl_pl, Ω_pl-Ω_ref)
             end
             println(f, inclmut_sys)
         end

--- a/src/clusters.jl
+++ b/src/clusters.jl
@@ -3,9 +3,10 @@ using ExoplanetsSysSim
 
 #include("param_custom.jl")
 include("param_common.jl")
-include("model_amd_system.jl")
+include("model_old.jl")
 include("summary_stats.jl")
 include("distance.jl")
+include("spherical_geometry.jl")
 #include("stellar_catalog.jl")
 
 include("mr_model/MRpredict.jl")

--- a/src/model_old.jl
+++ b/src/model_old.jl
@@ -350,14 +350,22 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     # Now assign orbits with given periods, sizes, and masses.
     sigma_incl = deg2rad(get_real(sim_param, "sigma_incl"))
     sigma_incl_near_mmr = deg2rad(get_real(sim_param, "sigma_incl_near_mmr"))
-    max_incl_sys = get_real(sim_param, "max_incl_sys")
     f_high_incl = get_real(sim_param, "f_high_incl")
 
     sigma_incl_use = rand() < f_high_incl ? max(sigma_incl, sigma_incl_near_mmr) : min(sigma_incl, sigma_incl_near_mmr)
 
+    # Assign a reference (invariant) plane for the system:
+    # NOTE: aligning sky plane to x-y plane (z-axis is unit normal)
+    vec_z = [0.,0.,1.]
+
+    vec_sys = draw_random_normal_vector() # unit normal of reference plane
+    incl_sys = calc_angle_between_vectors(vec_z, vec_sys) # inclination of reference plane (rad) relative to sky plane
+    Ω_sys = calc_Ω_in_sky_plane(vec_sys) # argument of ascending node of reference plane (rad) relative to sky plane
+
+    sys_ref_plane = SystemPlane(incl_sys, Ω_sys)
+
     pl = Array{Planet}(undef, num_pl)
     orbit = Array{Orbit}(undef, num_pl)
-    incl_sys = acos(cos(max_incl_sys*pi/180)*rand()) #acos(rand()) for isotropic distribution of system inclinations; acos(cos(X*pi/180)*rand()) gives angles from X (deg) to 90 (deg)
     idx = sortperm(Plist)       # TODO OPT: Check to see if sorting is significant time sink.  If so, could reduce redundant sortperm
     is_near_resonance = calc_if_near_resonance(Plist[idx], sim_param)
     for i in 1:num_pl
@@ -376,12 +384,15 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         #
         asc_node = 2pi*rand()
         mean_anom = 2pi*rand()
-        incl = incl_mut!=zero(incl_mut) ? acos(cos(incl_sys)*cos(incl_mut) + sin(incl_sys)*sin(incl_mut)*cos(asc_node)) : incl_sys
-        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], incl_mut, incl, omegalist[idx[i]], asc_node, mean_anom)
+
+        # Calculate the sky orientations of each orbit:
+        inclsky, Ωsky = calc_sky_incl_Ω_orbits_given_system_vector([incl_mut], [asc_node], vec_sys)
+
+        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky[1], omegalist[idx[i]], Ωsky[1], mean_anom)
         pl[i] = Planet(Rlist[idx[i]], masslist[idx[i]], clusteridlist[idx[i]])
     end # for i in 1:num_pl
 
-    return PlanetarySystem(star, pl, orbit)
+    return PlanetarySystem(star, pl, orbit, sys_ref_plane)
 end
 
 function generate_planetary_system_non_clustered(star::StarAbstract, sim_param::SimParam; verbose::Bool=false)
@@ -478,14 +489,22 @@ function generate_planetary_system_non_clustered(star::StarAbstract, sim_param::
     # Now assign orbits with given periods, sizes, and masses.
     sigma_incl = deg2rad(get_real(sim_param, "sigma_incl"))
     sigma_incl_near_mmr = deg2rad(get_real(sim_param, "sigma_incl_near_mmr"))
-    max_incl_sys = get_real(sim_param, "max_incl_sys")
     f_high_incl = get_real(sim_param, "f_high_incl")
 
     sigma_incl_use = rand() < f_high_incl ? max(sigma_incl, sigma_incl_near_mmr) : min(sigma_incl, sigma_incl_near_mmr)
 
+    # Assign a reference (invariant) plane for the system:
+    # NOTE: aligning sky plane to x-y plane (z-axis is unit normal)
+    vec_z = [0.,0.,1.]
+
+    vec_sys = draw_random_normal_vector() # unit normal of reference plane
+    incl_sys = calc_angle_between_vectors(vec_z, vec_sys) # inclination of reference plane (rad) relative to sky plane
+    Ω_sys = calc_Ω_in_sky_plane(vec_sys) # argument of ascending node of reference plane (rad) relative to sky plane
+
+    sys_ref_plane = SystemPlane(incl_sys, Ω_sys)
+
     pl = Array{Planet}(undef, num_pl)
     orbit = Array{Orbit}(undef, num_pl)
-    incl_sys = acos(cos(max_incl_sys*pi/180)*rand()) #acos(rand()) for isotropic distribution of system inclinations; acos(cos(X*pi/180)*rand()) gives angles from X (deg) to 90 (deg)
     idx = sortperm(Plist)       # TODO OPT: Check to see if sorting is significant time sink.  If so, could reduce redundant sortperm
     is_near_resonance = calc_if_near_resonance(Plist[idx], sim_param)
     for i in 1:num_pl
@@ -504,12 +523,15 @@ function generate_planetary_system_non_clustered(star::StarAbstract, sim_param::
         #
         asc_node = 2pi*rand()
         mean_anom = 2pi*rand()
-        incl = incl_mut!=zero(incl_mut) ? acos(cos(incl_sys)*cos(incl_mut) + sin(incl_sys)*sin(incl_mut)*cos(asc_node)) : incl_sys
-        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], incl_mut, incl, omegalist[idx[i]], asc_node, mean_anom)
+
+        # Calculate the sky orientations of each orbit:
+        inclsky, Ωsky = calc_sky_incl_Ω_orbits_given_system_vector([incl_mut], [asc_node], vec_sys)
+
+        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky[1], omegalist[idx[i]], Ωsky[1], mean_anom)
         pl[i] = Planet(Rlist[idx[i]], masslist[idx[i]])
     end # for i in 1:num_pl
 
-    return PlanetarySystem(star, pl, orbit)
+    return PlanetarySystem(star, pl, orbit, sys_ref_plane)
 end
 
 function test_generate_planetary_system_clustered() # TODO: Update to test to not reply on generate_kepler_physical_catalog

--- a/src/spherical_geometry.jl
+++ b/src/spherical_geometry.jl
@@ -1,0 +1,113 @@
+using LinearAlgebra
+
+# NOTE: in all of these functions, the "sky plane" is the x-y plane (unit normal vector aligned with the z-axis), where relevant.
+
+"""
+Draw a random unit vector isotropically, in cartesian coordinates.
+"""
+function draw_random_normal_vector()
+    u = 2*rand() - 1 # uniform in [-1,1]
+    θ = 2π*rand()
+
+    x = sqrt(1-u^2)*cos(θ)
+    y = sqrt(1-u^2)*sin(θ)
+    return [x,y,u]
+end
+
+Rx(θ) = [1 0 0; 0 cos(θ) -sin(θ); 0 sin(θ) cos(θ)] # rotation matrix around x-axis
+Ry(θ) = [cos(θ) 0 sin(θ); 0 1 0; -sin(θ) 0 cos(θ)] # rotation matrix around y-axis
+Rz(θ) = [cos(θ) -sin(θ) 0; sin(θ) cos(θ) 0; 0 0 1] # rotation matrix around z-axis
+
+"""
+Calculate the rotation matrix that would align vector A to B.
+Does not work if A = -B.
+"""
+function calc_rotation_matrix_A_to_B(A::Vector{Float64}, B::Vector{Float64})
+    @assert(length(A) == length(B) == 3)
+
+    v = cross(A, B)
+    s = norm(v)
+    c = dot(A, B)
+    vx = [0 -v[3] v[2]; v[3] 0 -v[1]; -v[2] v[1] 0]
+
+    R = I + vx + ((1-c)/s^2)*vx^2
+    return R
+end
+
+calc_angle_between_vectors(A::Vector{Float64}, B::Vector{Float64}) = acos(dot(A,B)/(norm(A)*norm(B))) # angle between two vectors
+
+"""
+Calculate the orientation of a vector in the x-y plane (normal to z-axis).
+"""
+function calc_Ω_in_sky_plane(h::Vector{Float64})
+    n = [-h[2],h[1],0.]
+    Ω = acos(n[1]/norm(n))
+    n[2] >= 0 ? Ω : 2π - Ω
+end
+
+"""
+Calculate the angle between two orbits using the spherical law of Cosines.
+"""
+function calc_incl_spherical_cosine_law(i1::Float64, i2::Float64, ΔΩ::Float64)
+    return acos(cos(i1)*cos(i2) + sin(i1)*sin(i2)*cos(ΔΩ))
+end
+
+
+
+
+
+"""
+    calc_orbit_vector_given_system_vector(i_m, Ω, vec_ref)
+
+Calculate the orbit normal vector given an inclination `i_m` and argument of ascending node `Ω` relative to a system reference plane, in cartesian coordinates.
+
+# Arguments:
+- `i_m::Float64`: inclination of orbit (rad) relative to the reference plane.
+- `Ω::Float64`: argument of ascending node (rad) relative to the reference plane.
+- `vec_ref::Vector{Float64}`: unit normal vector for the reference plane.
+
+# Returns:
+- `vec_orb::Vector{Float64}`: unit normal vector for the orbit.
+"""
+function calc_orbit_vector_given_system_vector(i_m::Float64, Ω::Float64, vec_ref::Vector{Float64})
+    @assert(length(vec_ref) == 3)
+
+    # Calculate rotation matrix that rotates z-axis to vec_ref:
+    vec_z = [0.,0.,1.]
+    inv_R = calc_rotation_matrix_A_to_B(vec_z, vec_ref)
+
+    # Rotate vec_z to get the orbit normal vector:
+    vec_orb = Rx(i_m)*vec_z; # rotate by i_m around x-axis
+    vec_orb = Rz(Ω)*vec_orb; # rotate by Ω around z-axis
+    vec_orb = inv_R*vec_orb; # rotate by inverse rotation matrix
+
+    return vec_orb
+end
+
+"""
+    calc_sky_incl_Ω_orbits_given_system_vector(i_m_list, Ω_list, vec_ref)
+
+Calculate the inclination and orientation relative to the sky plane for all orbits in the system, given a list of mutual inclinations and arguments of ascending nodes relative to the system reference plane.
+
+# Arguments:
+- `i_m_list::Vector{Float64}`: list of orbit inclinations (rad) relative to the reference plane.
+- `Ω_list::Vector{Float64}`: list of arguments of ascending node (rad) relative to the reference plane.
+- `vec_ref::Vector{Float64}`: unit normal vector for the reference plane.
+
+# Returns:
+- `i_sky_list::Vector{Float64}`: list of orbit inclinations (rad) relative to the sky plane.
+- `Ω_sky_list::Vector{Float64}`: list of arguments of ascending node (rad) relative to the sky plane.
+"""
+function calc_sky_incl_Ω_orbits_given_system_vector(i_m_list::Vector{Float64}, Ω_list::Vector{Float64}, vec_ref::Vector{Float64})
+    n_pl = length(i_m_list)
+    vec_z = [0.,0.,1.]
+
+    i_sky_list = Vector{Float64}(undef, n_pl)
+    Ω_sky_list = Vector{Float64}(undef, n_pl)
+    for i in 1:n_pl
+        vec_orb = calc_orbit_vector_given_system_vector(i_m_list[i], Ω_list[i], vec_ref)
+        i_sky_list[i] = calc_angle_between_vectors(vec_z, vec_orb)
+        Ω_sky_list[i] = calc_Ω_in_sky_plane(vec_orb)
+    end
+    return i_sky_list, Ω_sky_list
+end


### PR DESCRIPTION
Replace old way of only drawing an inclination angle for the reference plane to drawing full 3d vectors and calculating relative inclinations and arguments of ascending nodes using them.
That way, we can compute the mutual inclinations (between orbits and system reference planes) using the other information in Orbit and PlanetarySystem (i.e. inclinations and arguments relative to the sky plane) instead of saving them directly to Orbit.

The output files from generating catalogs should be the same as before.