### PR TITLE
Update way we draw reference planes

### DIFF
--- a/examples/generate_catalogs.jl
+++ b/examples/generate_catalogs.jl
@@ -1,6 +1,7 @@
 dir_path = dirname(@__FILE__)
 
 include(joinpath(dir_path, "../src/clusters.jl"))
+include(joinpath(dir_path, "../src/planetary_catalog.jl"))
 
 ##### To generate one physical and observed catalog:
 

--- a/examples/generate_catalogs_multiple.jl
+++ b/examples/generate_catalogs_multiple.jl
@@ -1,6 +1,7 @@
 dir_path = dirname(@__FILE__)
 
 include(joinpath(dir_path, "../src/clusters.jl"))
+include(joinpath(dir_path, "../src/planetary_catalog.jl"))
 
 sim_param = setup_sim_param_model()
 add_param_fixed(sim_param,"num_targets_sim_pass_one", 79935*5)

--- a/src/AMD_stability/amd_stability.jl
+++ b/src/AMD_stability/amd_stability.jl
@@ -560,7 +560,7 @@ function distribute_AMD_planet_ecc_incl_random(AMD::Real, μ::Real, a::Real)
     e = sqrt(xsq + ysq) # eccentricity
     ω = atan(x, y) # argument of pericenter
     i = asin(sqrt(zsq)) # inclination relative to invariant plane (rad)
-    @assert(sqrt(1 - e^2)*cos(i) >= 1 - AMD/Λ) # NOTE: I expected this to be equal given how we assigned x^2+y^2+z^2 = (AMD/Λ)*(2 - AMD/Λ), but in practice it is >= (which does not break AMD stability since this implies the true AMD given (e,i) is less than the AMD provided)
+    #@assert(sqrt(1 - e^2)*cos(i) >= 1 - AMD/Λ) # NOTE: I expected this to be equal given how we assigned x^2+y^2+z^2 = (AMD/Λ)*(2 - AMD/Λ), but in practice it is >= (which does not break AMD stability since this implies the true AMD given (e,i) is less than the AMD provided)
     #@info("e = $e, ω = $(ω*180/π) deg, i = $(i*180/π) deg")
 
     return e, ω, i

--- a/src/catalog_simulation.jl
+++ b/src/catalog_simulation.jl
@@ -9,9 +9,14 @@ function save_physical_catalog(cat_phys::KeplerPhysicalCatalog, sim_param::SimPa
         if length(targ.sys) > 1 #this should never happen
             println("There is more than one system for a given target? Check index: ", i)
         end
-        if length(targ.sys[1].planet) > 0
-            for (j,planet) in enumerate(targ.sys[1].planet)
-                println(f, join([i, targ.sys[1].star.id, planet.mass, planet.radius, planet.id, targ.sys[1].orbit[j].P, targ.sys[1].orbit[j].ecc, targ.sys[1].orbit[j].incl_mut, targ.sys[1].star.mass, targ.sys[1].star.radius], ","))
+        sys = targ.sys[1]
+        if length(sys.planet) > 0
+            incl_ref = sys.system_plane.incl
+            Ω_ref = sys.system_plane.asc_node
+            for (j,planet) in enumerate(sys.planet)
+                incl_pl, Ω_pl = sys.orbit[j].incl, sys.orbit[j].asc_node
+                inclmut_pl = calc_incl_spherical_cosine_law(incl_ref, incl_pl, Ω_pl-Ω_ref)
+                println(f, join([i, sys.star.id, planet.mass, planet.radius, planet.id, sys.orbit[j].P, sys.orbit[j].ecc, inclmut_pl, sys.star.mass, sys.star.radius], ","))
             end
         end
     end
@@ -27,7 +32,8 @@ function save_physical_catalog_stars_only(cat_phys::KeplerPhysicalCatalog, sim_p
         if length(targ.sys) > 1 #this should never happen
             println("There is more than one system for a given target? Check index: ", i)
         end
-        println(f, join([i, targ.sys[1].star.id, targ.sys[1].star.mass, targ.sys[1].star.radius, length(targ.sys[1].planet)], ","))
+        sys = targ.sys[1]
+        println(f, join([i, sys.star.id, sys.star.mass, sys.star.radius, length(sys.planet)], ","))
     end
     close(f)
 end
@@ -86,9 +92,12 @@ function save_mutualinclinations_all(cat_phys::KeplerPhysicalCatalog, sim_param:
     write_model_params(f, sim_param)
     for (i,targ) in enumerate(cat_phys.target)
         if length(targ.sys[1].orbit) > 0
+            incl_ref = targ.sys[1].system_plane.incl
+            Ω_ref = targ.sys[1].system_plane.asc_node
             inclmut_sys = Array{Float64}(undef, length(targ.sys[1].orbit))
             for (j,planet) in enumerate(targ.sys[1].orbit)
-                inclmut_sys[j] = planet.incl_mut
+                incl_pl, Ω_pl = planet.incl, planet.asc_node
+                inclmut_sys[j] = calc_incl_spherical_cosine_law(incl_ref, incl_pl, Ω_pl-Ω_ref)
             end
             println(f, inclmut_sys)
         end

--- a/src/clusters.jl
+++ b/src/clusters.jl
@@ -6,6 +6,7 @@ include("param_common.jl")
 include("model_amd_system.jl")
 include("summary_stats.jl")
 include("distance.jl")
+include("spherical_geometry.jl")
 #include("stellar_catalog.jl")
 
 include("mr_model/MRpredict.jl")

--- a/src/model.jl
+++ b/src/model.jl
@@ -31,8 +31,8 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam, incl_sys::Flo
         P = [1.0] # generate_periods_power_law(star,sim_param)
         eccentricity::Float64, omega_e::Float64 = generate_e_omega(sigma_ecc)::Tuple{Float64,Float64}
         ecc, omega = [eccentricity], [omega_e]
-        asc_node, mean_anom, incl, incl_mut = [2pi*rand()], [2pi*rand()], [incl_sys], [0.]
-        return (P, R, mass, ecc, omega, asc_node, mean_anom, incl, incl_mut)
+        asc_node, mean_anom, incl_mut = [2pi*rand()], [2pi*rand()], [0.]
+        return (P, R, mass, ecc, omega, asc_node, mean_anom, incl_mut)
     end
 
     # If reach here, then at least 2 planets in cluster
@@ -50,13 +50,12 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam, incl_sys::Flo
     log_mean_P = 0.0 # log(generate_periods_power_law(star,sim_param))
     Pdist = Truncated(LogNormal(log_mean_P,sigma_logperiod_per_pl_in_cluster*n), 1/sqrt(max_period_ratio), sqrt(max_period_ratio)) # truncated unscaled period distribution to ensure that the cluster can fit in the period range [min_period, max_period] after scaling by a period scale
     local P
-    local ecc, omega, asc_nodes, mean_anoms, incls
+    local ecc, omega, asc_nodes, mean_anoms
     ecc = Array{Float64}(undef, n)
     omega = Array{Float64}(undef, n)
     asc_nodes = Array{Float64}(undef, n)
     mean_anoms = Array{Float64}(undef, n)
     incls_mut = Array{Float64}(undef, n)
-    incls = Array{Float64}(undef, n)
 
     found_stable_cluster = false # will be true if entire cluster is stable (given sizes/masses, periods, eccentricities, and mutual inclinations)
     max_attempts = 100
@@ -112,7 +111,7 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam, incl_sys::Flo
                 mean_anom = 2pi*rand()
                 incl = incl_mut != zero(incl_mut) ? acos(cos(incl_sys)*cos(incl_mut) + sin(incl_sys)*sin(incl_mut)*cos(asc_node)) : incl_sys
 
-                asc_nodes[idx[i]], mean_anoms[idx[i]], incls_mut[idx[i]], incls[idx[i]] = asc_node, mean_anom, incl_mut, incl
+                asc_nodes[idx[i]], mean_anoms[idx[i]], incls_mut[idx[i]] = asc_node, mean_anom, incl_mut
             end
 
             μ = mass./star.mass
@@ -129,9 +128,9 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam, incl_sys::Flo
 
     if !found_stable_cluster
         #println("# Warning: Did not find a good set of sizes, masses, periods, eccentricities, and mutual inclinations for one cluster.")
-        return (fill(NaN,n), R, mass, ecc, omega, asc_nodes, mean_anoms, incls, incls_mut)  # Return NaNs for periods to indicate failed
+        return (fill(NaN,n), R, mass, ecc, omega, asc_nodes, mean_anoms, incls_mut)  # Return NaNs for periods to indicate failed
     end
-    return (P, R, mass, ecc, omega, asc_nodes, mean_anoms, incls, incls_mut) # NOTE: can also return earlier if only one planet in cluster or if fail to generate a good set of values; also, the planets are NOT sorted at this point
+    return (P, R, mass, ecc, omega, asc_nodes, mean_anoms, incls_mut) # NOTE: can also return earlier if only one planet in cluster or if fail to generate a good set of values; also, the planets are NOT sorted at this point
 end
 
 function generate_num_clusters_poisson(s::Star, sim_param::SimParam)
@@ -176,7 +175,6 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
 
     sigma_incl = deg2rad(get_real(sim_param, "sigma_incl"))
     sigma_incl_near_mmr = deg2rad(get_real(sim_param, "sigma_incl_near_mmr"))
-    max_incl_sys = get_real(sim_param, "max_incl_sys")
     f_high_incl = get_real(sim_param, "f_high_incl")
     sigma_incl_use = rand() < f_high_incl ? max(sigma_incl, sigma_incl_near_mmr) : min(sigma_incl, sigma_incl_near_mmr)
 
@@ -186,13 +184,18 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         return PlanetarySystem(star)
     end
 
-    # Assign a reference plane for the system:
-    incl_sys = acos(cos(max_incl_sys*pi/180)*rand()) # acos(rand()) for isotropic distribution of system inclinations; acos(cos(X*pi/180)*rand()) gives angles from X (deg) to 90 (deg)
+    # Assign a reference (invariant) plane for the system:
+    # NOTE: aligning sky plane to x-y plane (z-axis is unit normal)
+    vec_z = [0.,0.,1.]
+
+    vec_sys = draw_random_normal_vector() # unit normal of reference plane
+    incl_sys = calc_angle_between_vectors(vec_z, vec_sys) # inclination of reference plane (rad) relative to sky plane
+    Ω_sys = calc_Ω_in_sky_plane(vec_sys) # argument of ascending node of reference plane (rad) relative to sky plane
 
     # Generate a set of periods, planet radii, and planet masses:
     attempts_system = 0
     max_attempts_system = 1 # NOTE: currently this should not matter; each system is always attempted just once
-    local num_pl, clusteridlist, Plist, Rlist, masslist, ecclist, omegalist, ascnodelist, meananomlist, incllist, inclmutlist
+    local num_pl, clusteridlist, Plist, Rlist, masslist, ecclist, omegalist, ascnodelist, meananomlist, inclmutlist, inclskylist, Ωskylist
     valid_system = false
     while !valid_system && attempts_system < max_attempts_system
 
@@ -215,7 +218,6 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         omegalist::Array{Float64,1} = Array{Float64}(undef, num_pl)
         ascnodelist::Array{Float64,1} = Array{Float64}(undef, num_pl)
         meananomlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
-        incllist::Array{Float64,1} = Array{Float64}(undef, num_pl)
         inclmutlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
 
         @assert(num_pl_in_cluster[1] >= 1)
@@ -226,12 +228,12 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
             pl_stop += n
 
             # Draw a stable cluster (with unscaled periods):
-            Plist_tmp::Array{Float64,1}, Rlist_tmp::Array{Float64,1}, masslist_tmp::Array{Float64,1}, ecclist_tmp::Array{Float64,1}, omegalist_tmp::Array{Float64,1}, ascnodelist_tmp::Array{Float64,1}, meananomlist_tmp::Array{Float64,1}, incllist_tmp::Array{Float64,1}, inclmutlist_tmp::Array{Float64,1} = generate_stable_cluster(star, sim_param, incl_sys, sigma_incl_use, n=num_pl_in_cluster[c])
+            Plist_tmp::Array{Float64,1}, Rlist_tmp::Array{Float64,1}, masslist_tmp::Array{Float64,1}, ecclist_tmp::Array{Float64,1}, omegalist_tmp::Array{Float64,1}, ascnodelist_tmp::Array{Float64,1}, meananomlist_tmp::Array{Float64,1}, inclmutlist_tmp::Array{Float64,1} = generate_stable_cluster(star, sim_param, incl_sys, sigma_incl_use, n=num_pl_in_cluster[c])
 
             clusteridlist[pl_start:pl_stop] = ones(Int64, num_pl_in_cluster[c])*c
             Rlist[pl_start:pl_stop], masslist[pl_start:pl_stop] = Rlist_tmp, masslist_tmp
             ecclist[pl_start:pl_stop], omegalist[pl_start:pl_stop] = ecclist_tmp, omegalist_tmp
-            ascnodelist[pl_start:pl_stop], meananomlist[pl_start:pl_stop], incllist[pl_start:pl_stop], inclmutlist[pl_start:pl_stop] = ascnodelist_tmp, meananomlist_tmp, incllist_tmp, inclmutlist_tmp
+            ascnodelist[pl_start:pl_stop], meananomlist[pl_start:pl_stop], inclmutlist[pl_start:pl_stop] = ascnodelist_tmp, meananomlist_tmp, inclmutlist_tmp
 
             # New sampling:
             idx = .!isnan.(Plist[1:pl_stop-n])
@@ -305,7 +307,6 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
             omegalist = omegalist[keep]
             ascnodelist = ascnodelist[keep]
             meananomlist = meananomlist[keep]
-            incllist = incllist[keep]
             inclmutlist = inclmutlist[keep]
         end
 
@@ -352,13 +353,17 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     end
     =#
 
+    # Calculate the sky orientations of each orbit:
+    inclskylist, Ωskylist = calc_sky_incl_Ω_orbits_given_system_vector(inclmutlist, ascnodelist, vec_sys)
+
     pl = Array{Planet}(undef, num_pl)
     orbit = Array{Orbit}(undef, num_pl)
     idx = sortperm(Plist) # TODO OPT: Check to see if sorting is significant time sink. If so, could reduce redundant sortperm
     for i in 1:num_pl
-        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclmutlist[idx[i]], incllist[idx[i]], omegalist[idx[i]], ascnodelist[idx[i]], meananomlist[idx[i]])
+        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclskylist[idx[i]], omegalist[idx[i]], Ωskylist[idx[i]], meananomlist[idx[i]])
         pl[i] = Planet(Rlist[idx[i]], masslist[idx[i]], clusteridlist[idx[i]])
     end
+    sys_ref_plane = SystemPlane(incl_sys, Ω_sys)
 
-    return PlanetarySystem(star, pl, orbit)
+    return PlanetarySystem(star, pl, orbit, sys_ref_plane)
 end

--- a/src/model_amd_system.jl
+++ b/src/model_amd_system.jl
@@ -45,7 +45,7 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam; n::Int64=1) w
 
     # Draw unscaled periods first, checking for mutual Hill separation stability assuming circular and coplanar orbits
 
-    # New sampling:
+    #= New sampling:
     P = zeros(n)
     for i in 1:n # Draw periods one at a time
         if any(isnan.(P))
@@ -57,9 +57,9 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam; n::Int64=1) w
     end
     found_good_periods = all(isnan.(P)) ? false : true
     @assert(test_stability(P, mass, star.mass, sim_param)) # should always be true if our unscaled period draws are correct
-    #
+    =#
 
-    #= Old rejection sampling:
+    # Old rejection sampling:
     found_good_periods = false # will be true if entire cluster is likely to be stable assuming circular and coplanar orbits (given sizes/masses and periods)
     max_attempts = 100
     attempts_periods = 0
@@ -70,7 +70,7 @@ function generate_stable_cluster(star::StarT, sim_param::SimParam; n::Int64=1) w
             found_good_periods = true
         end
     end # while trying to draw periods
-    =#
+    #
 
     return (P, R, mass) # NOTE: can also return earlier if only one planet in cluster; also, the planets are NOT sorted at this point
 end
@@ -133,19 +133,22 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     min_period = get_real(sim_param, "min_period")
     max_period = get_real(sim_param, "max_period")
 
-    max_incl_sys = get_real(sim_param, "max_incl_sys")
-
     # Decide whether to assign a planetary system to the star at all:
     if rand() > f_stars_with_planets_attempted
         #println("Star not assigned a planetary system.")
         return PlanetarySystem(star)
     end
 
-    # Assign a reference plane (inclination of invariant plane) for the system:
-    incl_sys = acos(cos(max_incl_sys*pi/180)*rand()) # acos(rand()) for isotropic distribution of system inclinations; acos(cos(X*pi/180)*rand()) gives angles from X (deg) to 90 (deg)
+    # Assign a reference (invariant) plane for the system:
+    # NOTE: aligning sky plane to x-y plane (z-axis is unit normal)
+    vec_z = [0.,0.,1.]
+
+    vec_sys = draw_random_normal_vector() # unit normal of reference plane
+    incl_sys = calc_angle_between_vectors(vec_z, vec_sys) # inclination of reference plane (rad) relative to sky plane
+    Ω_sys = calc_Ω_in_sky_plane(vec_sys) # argument of ascending node of reference plane (rad) relative to sky plane
 
     # Generate a set of periods, planet radii, and planet masses:
-    local num_pl, clusteridlist, Plist, Rlist, masslist, ecclist, ωlist, Ωlist, meananomlist, inclmutlist, incllist
+    local num_pl, clusteridlist, Plist, Rlist, masslist, ecclist, ωlist, Ωlist, meananomlist, inclmutlist, inclskylist, Ωskylist
 
     # First, generate number of clusters (to attempt) and planets (to attempt) in each cluster:
     num_clusters = generate_num_clusters(star, sim_param)::Int64
@@ -176,7 +179,7 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         clusteridlist[pl_start:pl_stop] = ones(Int64, num_pl_in_cluster[c])*c
         Rlist[pl_start:pl_stop], masslist[pl_start:pl_stop] = Rlist_tmp, masslist_tmp
 
-        # New sampling:
+        #= New sampling:
         idx = .!isnan.(Plist[1:pl_stop-n])
         idy = .!isnan.(Plist_tmp)
         if any(idy)
@@ -198,9 +201,9 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
             break
         end
         @assert(test_stability(view(Plist,1:pl_stop), view(masslist,1:pl_stop), star.mass, sim_param)) # should always be true if our period scale draws are correct
-        #
+        =#
 
-        #= Old rejection sampling:
+        # Old rejection sampling:
         valid_cluster = !any(isnan.(Plist_tmp)) # if the cluster has any nans, the whole cluster is discarded
         valid_period_scale = false
         max_attempts_period_scale = 100
@@ -226,7 +229,7 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         if !valid_period_scale
             Plist[pl_start:pl_stop] .= NaN
         end
-        =#
+        #
 
         num_pl_in_cluster_true[c] = sum(.!isnan.(Plist[pl_start:pl_stop]))
         pl_start += n
@@ -262,15 +265,19 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     Ωlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
     meananomlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
     inclmutlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
-    incllist::Array{Float64,1} = Array{Float64}(undef, num_pl)
     AMDlist::Array{Float64,1} = Array{Float64}(undef, num_pl)
 
     μlist = masslist ./ star.mass # mass ratios
     alist = map(P -> semimajor_axis(P, star.mass), Plist)
     AMDlist, ecclist, ωlist, inclmutlist = draw_ecc_incl_system_critical_AMD(μlist, alist; check_stability=false)
 
-    Ωlist, meananomlist = 2π .* rand(num_pl), 2π .* rand(num_pl)
-    incllist = acos.(cos(incl_sys) .* cos.(inclmutlist) .+ sin(incl_sys) .* sin.(inclmutlist) .* cos.(Ωlist))
+    Ωlist, meananomlist = 2π .* rand(num_pl), 2π .* rand(num_pl) # relative to the reference plane
+
+    # Calculate the sky orientations of each orbit:
+    inclskylist::Array{Float64,1} = Array{Float64}(undef, num_pl)
+    Ωskylist::Array{Float64,1} = Array{Float64}(undef, num_pl)
+
+    inclskylist, Ωskylist = calc_sky_incl_Ω_orbits_given_system_vector(inclmutlist, Ωlist, vec_sys)
 
     #= For debugging:
     println("P (d): ", Plist)
@@ -279,7 +286,7 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     println("e: ", ecclist)
     println("ω (deg): ", ωlist .* 180/π)
     println("i_m (deg): ", inclmutlist .* 180/π)
-    println("i (deg): ", incllist .* 180/π)
+    println("i (deg): ", inclskylist .* 180/π)
     println("AMD: ", AMDlist)
     =#
 
@@ -293,8 +300,9 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
     orbit = Array{Orbit}(undef, num_pl)
     for i in 1:num_pl
         pl[i] = Planet(Rlist[i], masslist[i], clusteridlist[i])
-        orbit[i] = Orbit(Plist[i], ecclist[i], inclmutlist[i], incllist[i], ωlist[i], Ωlist[i], meananomlist[i])
+        orbit[i] = Orbit(Plist[i], ecclist[i], inclskylist[i], ωlist[i], Ωskylist[i], meananomlist[i])
     end
+    sys_ref_plane = SystemPlane(incl_sys, Ω_sys)
 
-    return PlanetarySystem(star, pl, orbit)
+    return PlanetarySystem(star, pl, orbit, sys_ref_plane)
 end

--- a/src/model_old.jl
+++ b/src/model_old.jl
@@ -388,7 +388,7 @@ function generate_planetary_system_clustered(star::StarAbstract, sim_param::SimP
         # Calculate the sky orientations of each orbit:
         inclsky, Ωsky = calc_sky_incl_Ω_orbits_given_system_vector([incl_mut], [asc_node], vec_sys)
 
-        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky, omegalist[idx[i]], Ωsky, mean_anom)
+        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky[1], omegalist[idx[i]], Ωsky[1], mean_anom)
         pl[i] = Planet(Rlist[idx[i]], masslist[idx[i]], clusteridlist[idx[i]])
     end # for i in 1:num_pl
 
@@ -527,7 +527,7 @@ function generate_planetary_system_non_clustered(star::StarAbstract, sim_param::
         # Calculate the sky orientations of each orbit:
         inclsky, Ωsky = calc_sky_incl_Ω_orbits_given_system_vector([incl_mut], [asc_node], vec_sys)
 
-        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky, omegalist[idx[i]], Ωsky, mean_anom)
+        orbit[i] = Orbit(Plist[idx[i]], ecclist[idx[i]], inclsky[1], omegalist[idx[i]], Ωsky[1], mean_anom)
         pl[i] = Planet(Rlist[idx[i]], masslist[idx[i]])
     end # for i in 1:num_pl
 

--- a/src/param_common.jl
+++ b/src/param_common.jl
@@ -53,11 +53,11 @@ function setup_sim_param_model(args::Vector{String} = Array{String}(undef, 0)) #
     # Generate_num_planets_in_cluster currently use these for the inclination distribution:
     add_param_fixed(sim_param,"resonance_width", 0.05)
     add_param_fixed(sim_param,"period_ratios_mmr", [2.0, 1.5, 4/3, 5/4])
-    add_param_active(sim_param,"f_high_incl", 0.4) # fraction of systems with higher mutual inclinations
-    add_param_active(sim_param,"sigma_incl", 50.) # degrees; 0 = coplanar w/ generate_kepler_target_simple; ignored by generate_planetary_system_uncorrelated_incl
-    add_param_active(sim_param,"sigma_incl_near_mmr", 1.3)
+    #add_param_active(sim_param,"f_high_incl", 0.4) # fraction of systems with higher mutual inclinations
+    #add_param_active(sim_param,"sigma_incl", 50.) # degrees; 0 = coplanar w/ generate_kepler_target_simple; ignored by generate_planetary_system_uncorrelated_incl
+    #add_param_active(sim_param,"sigma_incl_near_mmr", 1.3)
 
-    add_param_fixed(sim_param,"max_incl_sys", 0.0) # degrees; gives system inclinations from "max_incl_sys" (deg) to 90 (deg), so set to 0 for isotropic distribution of system inclinations; NOTE: make sure the difference between this and 90 (deg) is at least greater than "sigma_incl" and "sigma_incl_near_mmr"!
+    #add_param_fixed(sim_param,"max_incl_sys", 0.0) # degrees; gives system inclinations from "max_incl_sys" (deg) to 90 (deg), so set to 0 for isotropic distribution of system inclinations; NOTE: make sure the difference between this and 90 (deg) is at least greater than "sigma_incl" and "sigma_incl_near_mmr"!
 
     # Generate_num_planets_in_cluster currently use these for the eccentricity distribution:
     add_param_fixed(sim_param,"generate_e_omega", ExoplanetsSysSim.generate_e_omega_rayleigh)
@@ -66,7 +66,7 @@ function setup_sim_param_model(args::Vector{String} = Array{String}(undef, 0)) #
     add_param_active(sim_param,"sigma_hk", 0.018)
 
     # Generate_num_planets_in_cluster currently use these for the stability tests:
-    add_param_fixed(sim_param,"num_mutual_hill_radii", 8.0)
+    add_param_active(sim_param,"num_mutual_hill_radii", 8.0)
     add_param_fixed(sim_param,"generate_planet_mass_from_radius", generate_planet_mass_from_radius_Ning2018_table) # "ExoplanetsSysSim.generate_planet_mass_from_radius_powerlaw" or "generate_planet_mass_from_radius_Ning2018" or "generate_planet_mass_from_radius_Ning2018_table"
     add_param_active(sim_param,"sigma_log_radius_in_cluster", 0.3)
     add_param_active(sim_param,"sigma_logperiod_per_pl_in_cluster", 0.2)

--- a/src/spherical_geometry.jl
+++ b/src/spherical_geometry.jl
@@ -1,0 +1,113 @@
+using LinearAlgebra
+
+# NOTE: in all of these functions, the "sky plane" is the x-y plane (unit normal vector aligned with the z-axis), where relevant.
+
+"""
+Draw a random unit vector isotropically, in cartesian coordinates.
+"""
+function draw_random_normal_vector()
+    u = 2*rand() - 1 # uniform in [-1,1]
+    θ = 2π*rand()
+
+    x = sqrt(1-u^2)*cos(θ)
+    y = sqrt(1-u^2)*sin(θ)
+    return [x,y,u]
+end
+
+Rx(θ) = [1 0 0; 0 cos(θ) -sin(θ); 0 sin(θ) cos(θ)] # rotation matrix around x-axis
+Ry(θ) = [cos(θ) 0 sin(θ); 0 1 0; -sin(θ) 0 cos(θ)] # rotation matrix around y-axis
+Rz(θ) = [cos(θ) -sin(θ) 0; sin(θ) cos(θ) 0; 0 0 1] # rotation matrix around z-axis
+
+"""
+Calculate the rotation matrix that would align vector A to B.
+Does not work if A = -B.
+"""
+function calc_rotation_matrix_A_to_B(A::Vector{Float64}, B::Vector{Float64})
+    @assert(length(A) == length(B) == 3)
+
+    v = cross(A, B)
+    s = norm(v)
+    c = dot(A, B)
+    vx = [0 -v[3] v[2]; v[3] 0 -v[1]; -v[2] v[1] 0]
+
+    R = I + vx + ((1-c)/s^2)*vx^2
+    return R
+end
+
+calc_angle_between_vectors(A::Vector{Float64}, B::Vector{Float64}) = acos(dot(A,B)/(norm(A)*norm(B))) # angle between two vectors
+
+"""
+Calculate the orientation of a vector in the x-y plane (normal to z-axis).
+"""
+function calc_Ω_in_sky_plane(h::Vector{Float64})
+    n = [-h[2],h[1],0.]
+    Ω = acos(n[1]/norm(n))
+    n[2] >= 0 ? Ω : 2π - Ω
+end
+
+"""
+Calculate the angle between two orbits using the spherical law of Cosines.
+"""
+function calc_incl_spherical_cosine_law(i1::Float64, i2::Float64, ΔΩ::Float64)
+    return acos(cos(i1)*cos(i2) + sin(i1)*sin(i2)*cos(ΔΩ))
+end
+
+
+
+
+
+"""
+    calc_orbit_vector_given_system_vector(i_m, Ω, vec_ref)
+
+Calculate the orbit normal vector given an inclination `i_m` and argument of ascending node `Ω` relative to a system reference plane, in cartesian coordinates.
+
+# Arguments:
+- `i_m::Float64`: inclination of orbit (rad) relative to the reference plane.
+- `Ω::Float64`: argument of ascending node (rad) relative to the reference plane.
+- `vec_ref::Vector{Float64}`: unit normal vector for the reference plane.
+
+# Returns:
+- `vec_orb::Vector{Float64}`: unit normal vector for the orbit.
+"""
+function calc_orbit_vector_given_system_vector(i_m::Float64, Ω::Float64, vec_ref::Vector{Float64})
+    @assert(length(vec_ref) == 3)
+
+    # Calculate rotation matrix that rotates z-axis to vec_ref:
+    vec_z = [0.,0.,1.]
+    inv_R = calc_rotation_matrix_A_to_B(vec_z, vec_ref)
+
+    # Rotate vec_z to get the orbit normal vector:
+    vec_orb = Rx(i_m)*vec_z; # rotate by i_m around x-axis
+    vec_orb = Rz(Ω)*vec_orb; # rotate by Ω around z-axis
+    vec_orb = inv_R*vec_orb; # rotate by inverse rotation matrix
+
+    return vec_orb
+end
+
+"""
+    calc_sky_incl_Ω_orbits_given_system_vector(i_m_list, Ω_list, vec_ref)
+
+Calculate the inclination and orientation relative to the sky plane for all orbits in the system, given a list of mutual inclinations and arguments of ascending nodes relative to the system reference plane.
+
+# Arguments:
+- `i_m_list::Vector{Float64}`: list of orbit inclinations (rad) relative to the reference plane.
+- `Ω_list::Vector{Float64}`: list of arguments of ascending node (rad) relative to the reference plane.
+- `vec_ref::Vector{Float64}`: unit normal vector for the reference plane.
+
+# Returns:
+- `i_sky_list::Vector{Float64}`: list of orbit inclinations (rad) relative to the sky plane.
+- `Ω_sky_list::Vector{Float64}`: list of arguments of ascending node (rad) relative to the sky plane.
+"""
+function calc_sky_incl_Ω_orbits_given_system_vector(i_m_list::Vector{Float64}, Ω_list::Vector{Float64}, vec_ref::Vector{Float64})
+    n_pl = length(i_m_list)
+    vec_z = [0.,0.,1.]
+
+    i_sky_list = Vector{Float64}(undef, n_pl)
+    Ω_sky_list = Vector{Float64}(undef, n_pl)
+    for i in 1:n_pl
+        vec_orb = calc_orbit_vector_given_system_vector(i_m_list[i], Ω_list[i], vec_ref)
+        i_sky_list[i] = calc_angle_between_vectors(vec_z, vec_orb)
+        Ω_sky_list[i] = calc_Ω_in_sky_plane(vec_orb)
+    end
+    return i_sky_list, Ω_sky_list
+end


### PR DESCRIPTION
Replace old way of only drawing an inclination angle for the reference plane to drawing full 3d vectors and calculating relative inclinations and arguments of ascending nodes using them.
That way, we can compute the mutual inclinations (between orbits and system reference planes) using the other information in Orbit and PlanetarySystem (i.e. inclinations and arguments relative to the sky plane) instead of saving them directly to Orbit.

The output files from generating catalogs should be the same as before.